### PR TITLE
fix(chrome): preserve native text selection in composers

### DIFF
--- a/.github/ISSUE_DRAFT_selection-composer.md
+++ b/.github/ISSUE_DRAFT_selection-composer.md
@@ -1,0 +1,36 @@
+# [Bug] Text selection in composer is jumpy / interferes with invisible BiDi markers
+
+## Summary
+
+When selecting mixed Persian + English text in AI chat composers (especially **Claude.ai**), the selection highlight does not behave like native browser selection. Boundaries jump, ranges feel “broken”, or the DOM is rewritten while the user is drag-selecting.
+
+## Steps to reproduce
+
+1. Install BIDI - Forge and open **claude.ai**
+2. Type mixed text, e.g. `Hello سلام` or `1. Hello سلام`
+3. Click and drag to select part of the text
+
+## Expected
+
+- Selection behaves like a normal `contenteditable` field (continuous highlight, predictable start/end)
+
+## Actual
+
+- Selection feels wrong or resets while selecting
+- Invisible Unicode BiDi markers (LRM/RLM) in the live DOM confuse selection boundaries
+
+## Root cause (technical)
+
+- Inserting LRM/RLM into the live ProseMirror composer while typing
+- DOM rewrite during `selectionchange` / debounced input fixes
+- Caret restoration logic that only handled collapsed carets, not ranges
+
+## Proposed fix
+
+- **Claude**: CSS-only BiDi while focused; apply markers on **blur** only
+- Pause composer DOM fixes while the user has a non-collapsed selection
+- Restore full selection `Range` after block-level marker fixes when needed
+
+## Labels
+
+`bug`, `chrome-extension`, `claude`

--- a/packages/chrome-extension/src/__tests__/selectionGuard.test.ts
+++ b/packages/chrome-extension/src/__tests__/selectionGuard.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+import { isUserTextSelecting, shouldPauseComposerDomFix } from "../selectionGuard.js";
+
+describe("selectionGuard", () => {
+  let host: HTMLDivElement;
+
+  beforeEach(() => {
+    host = document.createElement("div");
+    host.setAttribute("contenteditable", "true");
+    host.textContent = "hello world";
+    document.body.append(host);
+  });
+
+  afterEach(() => {
+    window.getSelection()?.removeAllRanges();
+    host.remove();
+  });
+
+  it("returns false for collapsed caret", () => {
+    const sel = window.getSelection()!;
+    const range = document.createRange();
+    range.setStart(host.firstChild!, 2);
+    range.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(range);
+    expect(isUserTextSelecting()).toBe(false);
+    expect(shouldPauseComposerDomFix()).toBe(false);
+  });
+
+  it("returns true for non-collapsed selection in composer", () => {
+    const sel = window.getSelection()!;
+    const range = document.createRange();
+    range.setStart(host.firstChild!, 0);
+    range.setEnd(host.firstChild!, 5);
+    sel.removeAllRanges();
+    sel.addRange(range);
+    expect(isUserTextSelecting()).toBe(true);
+    expect(shouldPauseComposerDomFix()).toBe(true);
+  });
+});

--- a/packages/chrome-extension/src/adapters/__tests__/claudeComposer.test.ts
+++ b/packages/chrome-extension/src/adapters/__tests__/claudeComposer.test.ts
@@ -8,10 +8,17 @@ import {
 } from "../../cssOnlyComposer.js";
 
 describe("Claude composer strategy", () => {
-  it("uses full marker fix path, not CSS-only surface", () => {
+  it("uses CSS-only while typing and guards composer from marker spam", () => {
+    const prose = document.createElement("div");
+    prose.className = "ProseMirror";
+    prose.setAttribute("contenteditable", "true");
+    document.body.append(prose);
+
     expect(isClaudeLikeHost("claude.ai")).toBe(true);
     expect(isCssOnlySurface("claude.ai")).toBe(false);
-    expect(isCssOnlyComposer("claude.ai", document.createElement("div"))).toBe(false);
-    expect(isInsideCssOnlyComposer(document.createElement("p"), "claude.ai")).toBe(false);
+    expect(isCssOnlyComposer("claude.ai", prose)).toBe(true);
+    expect(isInsideCssOnlyComposer(prose, "claude.ai")).toBe(true);
+
+    prose.remove();
   });
 });

--- a/packages/chrome-extension/src/blockFix.ts
+++ b/packages/chrome-extension/src/blockFix.ts
@@ -200,13 +200,23 @@ export function lastStrongBeforeCaretLogical(block: HTMLElement): "ltr" | "rtl" 
   return lastStrongBeforeCaret(block);
 }
 
-export function tryFixMixedBlockCoalesced(block: HTMLElement): boolean {
+export interface FixBlockOptions {
+  /** Apply markers even inside CSS-only composers (e.g. Claude on blur). */
+  allowInCssOnlyComposer?: boolean;
+}
+
+export function tryFixMixedBlockCoalesced(
+  block: HTMLElement,
+  options?: FixBlockOptions,
+): boolean {
   if (block.closest("pre")) return false;
   if (block.matches("pre, code, kbd, samp")) return false;
   if (block.querySelector("pre, code, kbd, samp, a[href]")) return false;
 
   const host = typeof location !== "undefined" ? location.hostname : "";
-  if (host && isInsideCssOnlyComposer(block, host)) return false;
+  if (host && isInsideCssOnlyComposer(block, host) && !options?.allowInCssOnlyComposer) {
+    return false;
+  }
 
   const raw = stripBidiMarkers(block.textContent ?? "");
   if (!raw.trim() || !shouldFixMixedText(raw)) return false;
@@ -214,8 +224,15 @@ export function tryFixMixedBlockCoalesced(block: HTMLElement): boolean {
   const fixed = fixMixedText(raw);
   if (fixed === raw) return false;
 
+  const doc = block.ownerDocument;
+  const sel = doc.getSelection?.();
+  const hadRangeSelection =
+    sel && sel.rangeCount > 0 && !sel.isCollapsed && block.contains(sel.anchorNode);
+  const savedRange = hadRangeSelection ? sel.getRangeAt(0).cloneRange() : null;
+
   const focused = isBlockFocused(block);
-  const logicalCaret = focused ? getCaretLogicalOffsetInBlock(block) : null;
+  const logicalCaret =
+    focused && !hadRangeSelection ? getCaretLogicalOffsetInBlock(block) : null;
 
   let changed = false;
   if (block.childElementCount === 0) {
@@ -225,7 +242,14 @@ export function tryFixMixedBlockCoalesced(block: HTMLElement): boolean {
     changed = fixBlockCoalescedTextNodes(block, fixed);
   }
 
-  if (changed && focused && logicalCaret !== null) {
+  if (changed && savedRange) {
+    try {
+      sel.removeAllRanges();
+      sel.addRange(savedRange);
+    } catch {
+      /* range may be invalid after DOM rewrite */
+    }
+  } else if (changed && focused && logicalCaret !== null) {
     const domCaret = mapOffsetThroughMarkerFix(raw, fixed, logicalCaret);
     setCaretDomOffsetInBlock(block, domCaret);
   }

--- a/packages/chrome-extension/src/content.ts
+++ b/packages/chrome-extension/src/content.ts
@@ -4,10 +4,10 @@ import { tryFixMixedBlockCoalesced } from "./blockFix.js";
 import {
   applyBlockBidiStyles,
   applyBidiStylesToSubtree,
-  listComposerBlocks,
 } from "./bidiDomStyles.js";
 import { hookShadowRootsInTree, querySelectorAllDeepFrom } from "./domDeep.js";
 import {
+  applyComposerMarkersOnBlur,
   applyCssOnlyBidiOverrides,
   isCssOnlyComposer,
   isGoogleAiHost,
@@ -15,6 +15,8 @@ import {
   maintainCssOnlyComposer,
   resolveCssOnlyEditor,
 } from "./cssOnlyComposer.js";
+import { shouldPauseComposerDomFix } from "./selectionGuard.js";
+import { listComposerBlocks } from "./bidiDomStyles.js";
 import {
   scanMessageRoot,
   scanMessageSurfaces,
@@ -318,6 +320,7 @@ function listComposerBlocksFromRoot(root: HTMLElement): HTMLElement[] {
 function fixContentEditableRoot(root: HTMLElement, mode: "typing" | "full" = "typing"): boolean {
   if (!root.isContentEditable) return false;
   if (isInSkippedContainer(root)) return false;
+  if (mode === "typing" && shouldPauseComposerDomFix()) return false;
 
   const host = currentHostname();
   if (isCssOnlyComposer(host, root)) {
@@ -562,6 +565,18 @@ function flushQueue(): void {
   if (queued.size > 0) scheduleFlush();
 }
 
+function applyComposerMarkersOnBlurFix(el: Element, host: string): void {
+  const editor = resolveCssOnlyEditor(host, el);
+  if (!(editor instanceof HTMLElement)) return;
+  programmaticEdit.add(el);
+  runWithoutMutationFeedback(() => {
+    for (const block of listComposerBlocks(editor)) {
+      tryFixMixedBlockCoalesced(block, { allowInCssOnlyComposer: true });
+    }
+  });
+  programmaticEdit.delete(el);
+}
+
 function wireCssOnlyComposerEditable(el: Element): void {
   if (!(el instanceof HTMLElement)) return;
   const host = currentHostname();
@@ -570,6 +585,7 @@ function wireCssOnlyComposerEditable(el: Element): void {
   const editor = resolveCssOnlyEditor(host, el);
   const scheduleMaintain = () => {
     if (!enabled) return;
+    if (shouldPauseComposerDomFix()) return;
     if (programmaticEdit.has(el)) return;
     if (composing.get(el)) return;
     if (Date.now() < (skipComposerFixUntil.get(el) ?? 0)) return;
@@ -622,7 +638,11 @@ function wireCssOnlyComposerEditable(el: Element): void {
       scheduledInputFix.delete(el);
       if (!enabled || programmaticEdit.has(el)) return;
       const ed = resolveCssOnlyEditor(host, el);
-      if (ed) maintainCssOnlyComposerSafe(ed, el, "all");
+      if (applyComposerMarkersOnBlur(host)) {
+        applyComposerMarkersOnBlurFix(el, host);
+      } else if (ed) {
+        maintainCssOnlyComposerSafe(ed, el, "all");
+      }
     },
     { passive: true },
   );
@@ -646,6 +666,7 @@ function ensureEditableWired(el: Element): void {
 
   const runFix = (mode: "typing" | "full") => {
     if (!enabled) return;
+    if (mode === "typing" && shouldPauseComposerDomFix()) return;
     if (programmaticEdit.has(el)) return;
     if (composing.get(el)) return;
     if (Date.now() < (skipComposerFixUntil.get(el) ?? 0)) return;
@@ -665,6 +686,7 @@ function ensureEditableWired(el: Element): void {
 
   const schedule = () => {
     if (!enabled) return;
+    if (shouldPauseComposerDomFix()) return;
     if (programmaticEdit.has(el)) return;
     if (composing.get(el)) return;
     if (Date.now() < (skipComposerFixUntil.get(el) ?? 0)) return;

--- a/packages/chrome-extension/src/cssOnlyComposer.ts
+++ b/packages/chrome-extension/src/cssOnlyComposer.ts
@@ -7,8 +7,10 @@ import { stripBidiMarkers } from "@bidi-forge/core";
 
 import { isAdapterLiveComposer, resolveAdapterComposerEditor } from "./adapters/composerResolve.js";
 import { isCssOnlyAdapter, resolveAdapter } from "./adapters/registry.js";
+import { isChatGptHost } from "./adapters/chatgpt.js";
 import { isClaudeLikeHost } from "./adapters/claude.js";
 import { isGeminiHost } from "./adapters/gemini.js";
+import { isGrokSurface } from "./adapters/grok.js";
 import {
   applyBlockBidiStyles,
   applyListContainerBidiStyles,
@@ -241,6 +243,16 @@ function resolveClaudeEditor(hostname: string, anchor: Element): HTMLElement | n
     return anchor;
   }
 
+  if (
+    anchor instanceof HTMLElement &&
+    anchor.classList.contains("ProseMirror") &&
+    anchor.getAttribute("contenteditable") != null &&
+    anchor.getAttribute("contenteditable") !== "false" &&
+    !isInsideClaudeMessageBubble(anchor)
+  ) {
+    return anchor;
+  }
+
   return null;
 }
 
@@ -271,12 +283,17 @@ export function resolveCssOnlyEditor(hostname: string, anchor: Element | Node): 
 }
 
 export function isCssOnlyComposer(hostname: string, el: Element): boolean {
-  if (isClaudeLikeHost(hostname)) return false;
   const pathname = typeof location !== "undefined" ? location.pathname : "";
+  if (isClaudeLiveComposer(hostname, el)) return true;
   if (isGeminiQuillComposer(hostname, el)) return true;
   if (isGrokLiveComposer(hostname, el)) return true;
   if (isChatGptLiveComposer(hostname, el)) return true;
   return isAdapterLiveComposer(hostname, el, pathname);
+}
+
+/** Claude: CSS while typing; Unicode markers applied on blur before send. */
+export function applyComposerMarkersOnBlur(hostname: string): boolean {
+  return isClaudeLikeHost(hostname);
 }
 
 /** Accepts text nodes from MutationObserver targets (no `.closest`). */
@@ -285,9 +302,14 @@ export function isInsideCssOnlyComposer(
   hostname: string,
   pathname = "",
 ): boolean {
-  if (!isCssOnlySurface(hostname, pathname)) return false;
   const el = anchorElement(node);
   if (!el) return false;
+  if (isClaudeLikeHost(hostname)) {
+    const ed = resolveClaudeEditor(hostname, el);
+    if (!ed) return false;
+    return ed === el || ed.contains(node);
+  }
+  if (!isCssOnlySurface(hostname, pathname)) return false;
   if (isInsideGeminiComposer(el, hostname)) return true;
   const ed = resolveCssOnlyEditor(hostname, el);
   if (!ed) return false;

--- a/packages/chrome-extension/src/selectionGuard.ts
+++ b/packages/chrome-extension/src/selectionGuard.ts
@@ -1,0 +1,24 @@
+const EDITABLE_SELECTOR =
+  '[contenteditable="true"],textarea,[role="textbox"][contenteditable="true"]';
+
+function selectionInEditable(doc: Document): boolean {
+  const sel = doc.getSelection?.();
+  if (!sel || sel.rangeCount === 0) return false;
+
+  const node = sel.anchorNode;
+  if (!node) return false;
+
+  const el = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+  return Boolean(el?.closest(EDITABLE_SELECTOR));
+}
+
+/** True while the user is drag-selecting text in a composer (non-collapsed range). */
+export function isUserTextSelecting(doc: Document = document): boolean {
+  const sel = doc.getSelection?.();
+  if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return false;
+  return selectionInEditable(doc);
+}
+
+export function shouldPauseComposerDomFix(doc: Document = document): boolean {
+  return isUserTextSelecting(doc);
+}

--- a/scripts/create-selection-issue.sh
+++ b/scripts/create-selection-issue.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Create GitHub issue for composer selection bug (requires: gh auth login)
+set -euo pipefail
+REPO="${1:-BIDI-Forge/bidi-forge}"
+GH_BIN="${GH_BIN:-gh}"
+"$GH_BIN" issue create \
+  --repo "$REPO" \
+  --title "fix: composer text selection interferes with BiDi markers" \
+  --body-file ".github/ISSUE_DRAFT_selection-composer.md" \
+  --label bug


### PR DESCRIPTION
## Summary

Fixes #20

- Pause composer DOM fixes while the user drag-selects text (`selectionGuard`)
- **Claude**: CSS-only BiDi while focused; Unicode markers applied on **blur** only
- Restore full selection `Range` after block-level marker fixes

## Test plan

- [ ] Reload extension on `chrome://extensions`
- [ ] On claude.ai, type `Hello سلام` and drag-select — highlight should behave normally
- [ ] Blur composer — markers still applied for send/display
- [ ] `pnpm -C packages/chrome-extension test`